### PR TITLE
Add link flows and labels

### DIFF
--- a/stesso/gui/link_label.py
+++ b/stesso/gui/link_label.py
@@ -1,0 +1,186 @@
+from PySide2.QtWidgets import QGraphicsItem
+from PySide2.QtCore import Qt, QRectF, QPointF, QLineF, Slot
+from PySide2.QtGui import QBrush, QColor, QFont, QPen
+
+from .link_label_text import LinkLabelText
+
+from typing import Protocol, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .textinfo import TextInfo
+
+SCALE_VALUE = 22
+CHAR_WIDTH = 10
+
+
+class LinkItemData(Protocol):
+    @property
+    def key(self) -> tuple[int, int]:
+        ...
+    @property
+    def pts(self) -> list[tuple[float, float]]:
+        ...
+
+class LinkLabel(QGraphicsItem):
+    def __init__(self, 
+            self_link: LinkItemData,
+            text_info_grid: list[list['TextInfo']]
+        ) -> None:
+
+        super().__init__()
+
+        self.link = self_link
+        self.text_info_grid = text_info_grid
+        
+        self.line = \
+               QLineF(self.link.pts[0][0], self.link.pts[0][1],
+                      self.link.pts[1][0], self.link.pts[1][1])
+
+        self.angle = self.line.angle()
+        
+        self.flip = (self.angle > 90) and (self.angle <= 270)
+
+        if self.flip:
+             self.setRotation(-self.angle - 180)
+        else:
+            self.setRotation(-self.angle)
+
+        self.text_grid: list[list[LinkLabelText]] = []
+
+        # How many columns and rows of text?
+        self.n_cols = len(self.text_info_grid)
+        self.n_rows = len(self.text_info_grid[0])
+
+        self.col_max_char = []
+
+        for col in range(self.n_cols):
+            self.text_grid.append([])
+            self.col_max_char.append(0)
+        
+        # Add text items
+        for col in range(self.n_cols):
+            for row in range(self.n_rows):
+                text_info = self.text_info_grid[col][row]
+                new_text = LinkLabelText(
+                    parent=self, 
+                    text="0", 
+                    flip_text=False,
+                    key=self.link.key,
+                    text_info=text_info)
+                
+                self.text_grid[col].append(new_text)
+
+        self.height = SCALE_VALUE * self.n_rows
+        self.update_text()
+        # self.setRotation(-self.angle)
+        self.setFlag(QGraphicsItem.ItemIsMovable)
+
+
+    # @Slot(tuple, bool)
+    # def test_signal(self, key, selected):
+    #     print(f"slot from approach_label: {key} {selected}")
+    #     # self.show_input_dialog_fn(key, selected)
+
+    # def connect_txt_signals(self, show_dialog_fn, show_tm_hint_fn):
+    #     for col in self.text_columns:
+    #         # filter based on what the text is showing (assigned volume, target volume, etc)
+    #         if col['info'] != "assigned_volume":
+    #             continue
+    #         for txt in col['rows']:
+    #             txt.is_selectable = True
+    #             txt.signals.is_selected.connect(show_dialog_fn)
+    #             txt.signals.is_selected.connect(show_tm_hint_fn)
+
+    #             # For Debugging
+    #             txt.signals.is_selected.connect(self.test_signal)
+    
+    # def get_text_items(self) -> list[LabelText]:
+    #     items = []
+    #     for col in self.text_columns:
+    #         # filter based on what the text is showing (assigned volume, target volume, etc)
+    #         if col['info'] != "assigned_volume":
+    #             continue
+    #         for txt in col['rows']:
+    #             items.append(txt)
+        
+    #     return items
+
+    # def get_selected_text(self):
+    #     selected = []
+    #     for col in self.text_columns:
+    #         for txt in col['rows']:
+    #             if txt._debug_clicked:
+    #                 selected.append(txt.key)
+    #     return selected
+
+    def update_text(self):
+        self._reset_max_char()
+
+        for col in range(self.n_cols):
+            for row in range(self.n_rows):
+                new_text = self.text_grid[col][row].update_message()
+                self.col_max_char[col] = max(len(new_text), self.col_max_char[col])
+
+        self._update_text_pos()
+
+        self.width = 0
+        for col in range(self.n_cols):
+            self.width += self.col_max_char[col]
+
+        self.width = (self.width + self.n_cols) * CHAR_WIDTH
+
+    def _reset_max_char(self):
+        for i in range(len(self.col_max_char)):
+            self.col_max_char[i] = 0
+
+    def _update_text_pos(self):        
+        prev_col_x_pos = 0
+
+        for col in range(self.n_cols):
+            x_pos = prev_col_x_pos
+            for row in range(self.n_rows):
+                label = self.text_grid[col][row]
+                text_len = len(label.text) * CHAR_WIDTH
+                txt_offset = self.col_max_char[col] * CHAR_WIDTH - text_len
+                
+                label.setPos(x_pos + txt_offset, row * SCALE_VALUE)
+
+            prev_col_x_pos = x_pos + (self.col_max_char[col] * CHAR_WIDTH) + CHAR_WIDTH
+
+    def get_offset(self):
+        unit_normal = self.line.normalVector().unitVector()
+        
+        center_pt = self.line.center()
+        offset_pt = QPointF(center_pt.x() - self.line.p1().x(),
+                            center_pt.y() - self.line.p1().y())
+        
+        unit_normal.translate(offset_pt)
+
+        if self.flip:
+            unit_normal.setLength(20)
+        else:
+            unit_normal.setLength(20 + self.height)
+
+        return unit_normal.p2()
+
+    def boundingRect(self):
+        return QRectF(0, 0, self.width, self.height)
+
+    def paint(self, painter, option, widget) -> None:
+        # # Draw Bounding Rect for debugging
+        # brush = QBrush(QColor(240, 240, 0))
+        # painter.setBrush(brush)
+        if self.flip:
+            pen = QPen(QColor(255, 0, 0))
+        else:
+            pen = QPen(QColor(0, 255, 0))
+        
+        painter.setPen(pen)
+        painter.drawRect(self.boundingRect())
+        painter.drawEllipse(0,0,3,3)
+
+    # def mousePressEvent(self, event) -> None:
+    #     return super().mousePressEvent(event)
+
+    # def mouseReleaseEvent(self, event) -> None:
+    #     return super().mouseReleaseEvent(event)

--- a/stesso/gui/link_label_text.py
+++ b/stesso/gui/link_label_text.py
@@ -1,0 +1,73 @@
+from PySide2.QtWidgets import QGraphicsItem
+from PySide2.QtGui import QFont, QBrush, QPen, QColor
+from PySide2.QtCore import Qt, QRectF, QObject, Signal
+
+from .textinfo import TextInfo
+
+SCALE_VALUE = 22
+AVG_CHAR_WIDTH = 10
+
+class Communicate(QObject):
+    is_selected = Signal(tuple, bool)
+
+
+
+class LinkLabelText(QGraphicsItem):
+
+    def __init__(self, parent, text, flip_text: bool, key: tuple, text_info: TextInfo) -> None:
+        super().__init__(parent)
+        
+        self.text = text
+        self.flip = flip_text
+
+        self.key = key
+        self.info = text_info
+        
+        self.selected = False
+        self.signals = Communicate()
+        
+        self.setToolTip(f"{self.info.InfoType}: {self.text}")
+
+    def boundingRect(self):
+        return QRectF(0, 0, len(self.text) * AVG_CHAR_WIDTH, SCALE_VALUE)
+
+    def paint(self, painter, option, widget) -> None:
+
+        text_width = len(self.text) * AVG_CHAR_WIDTH
+        
+        if self.flip:
+            painter.translate(text_width, 0)
+            painter.scale(-1, 1)
+        else:
+            painter.translate(0, SCALE_VALUE)
+            painter.scale(1, -1)
+        
+        if self.selected:
+            # brush = QBrush(QColor(240, 240, 0))
+            # painter.setBrush(brush)
+            painter.drawRect(self.boundingRect())
+            painter.drawEllipse(0, 0, 3, 3)
+
+        pen = QPen(QColor(255, 0, 0))
+        painter.setPen(pen)
+
+        font = QFont("consolas", 14)
+        painter.setFont(font)
+
+        painter.drawText(0, 0, text_width, SCALE_VALUE, Qt.AlignRight, self.text)
+
+    def mousePressEvent(self, event) -> None:
+        print(f"link text mouse press: {self.text} editable? {self.info.editable}")
+        if not self.info.editable:
+            return
+            
+        self.selected = not self.selected
+        self.signals.is_selected.emit(self.key, self.selected)
+        self.update()
+    
+    def update_message(self):
+        new_text = self.info.get_text_fn(self.key)
+        self.text = f"{self.info.prefix}{new_text}{self.info.postfix}"
+        self.setToolTip(f"{self.info.InfoType}: {self.text}")
+        self.update()
+        return self.text

--- a/stesso/gui/mainwindow.py
+++ b/stesso/gui/mainwindow.py
@@ -123,7 +123,8 @@ class MainWindow(QMainWindow):
         self.schematic_scene.load_network(self.model.get_nodes(), 
                                           self.model.get_links(),
                                           self.model.get_nodes_to_label(),
-                                          self.model.get_turn_text)
+                                          self.model.get_turn_text,
+                                          self.model.get_link_text)
 
         self.schematic_scene.connect_txt_signals(self.show_input_dialog_fn)
 

--- a/stesso/gui/textinfo.py
+++ b/stesso/gui/textinfo.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Callable
+
+@dataclass
+class TextInfo:
+    editable: bool
+    InfoType: str
+    get_text_fn: Callable
+    prefix: str
+    postfix: str

--- a/stesso/model.py
+++ b/stesso/model.py
@@ -83,6 +83,10 @@ class Model():
 
         if turns_file is not None:
             net_read.import_turns(turns_file, self.net)
+            
+            # TODO: is this the best spot to make these function calls?
+            self.net.init_assigned_turn_vol()
+            self.net.calc_link_imbalance()
 
         return True
 
@@ -91,6 +95,8 @@ class Model():
             return
 
         balancer.balance_volumes(self.net)
+        # TODO: Calculate imbalance here, or within balance_volumes() ?
+        self.net.calc_link_imbalance()
 
     def get_nodes(self) -> list['NetNode']:
         """Return a list of nodes in the network."""
@@ -121,6 +127,24 @@ class Model():
                 text = "NA"
         
         return text
+
+    def get_link_text(self, link_key: tuple[int, int], data_name: str) -> str:
+        link = self.net.link(*link_key)
+
+        match data_name:
+            case "geh":
+                text = str(link.geh)
+            case "target_volume": 
+                text = f'{link.target_volume:.0f}'
+            case "assigned_volume": 
+                text = f'{link.assigned_volume:.0f}'
+            case "imbalance": 
+                text = f'{link.imbalance:.0f}'
+            case _:
+                text = "NA"
+        
+        return text
+
 
     def set_turn_volume(self, turn_key: tuple[int, int, int], volume: int) -> None:
         turn = self.net.turn(*turn_key)

--- a/stesso/network/net_read.py
+++ b/stesso/network/net_read.py
@@ -63,9 +63,10 @@ def create_network(node_file: str, link_file: str) -> Network:
     link_handler[link_file_ext](new_network, link_file)
 
     new_network.init_turns()
+    new_network.assign_link_flows()
     new_network.init_routes()
     new_network.set_coord_scale()
-
+    
     return new_network
 
 

--- a/stesso/network/netlink.py
+++ b/stesso/network/netlink.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 @dataclass(slots=True)
 class NetLinkData():
@@ -31,3 +31,6 @@ class NetLinkData():
     assigned_volume: float = 0
     seed_volume: float = 0
     geh: float = 0
+    imbalance: float = 0
+    turns_in: list[tuple[int, int, int]] = field(default_factory=list)
+    turns_out: list[tuple[int, int, int]] = field(default_factory=list)


### PR DESCRIPTION
Code addresses #4 by adding link flows in the data model and link labels in the GUI.

There is still work to do, but merging this pull request will lay the groundwork for additional functionality and improvements.

TODO: 
- While writing the code for the link labels, similarities to the turning movement labels emerged. There is likely an opportunity to simplify the code into a generic "label" class.
- This code breaks the balancing code if link imbalances are re-calculated after the automatic balancing is run. This is because the balancing code deletes u-turns that the network link flows are expecting. A fix could be implemented when #7 is worked on. 
