### PR TITLE
Update link volumes and balancer output

### DIFF
--- a/stesso/model.py
+++ b/stesso/model.py
@@ -94,8 +94,14 @@ class Model():
         if self.net is None:
             return
 
-        balancer.balance_volumes(self.net)
-        # TODO: Calculate imbalance here, or within balance_volumes() ?
+        result = balancer.balance_volumes(self.net)
+
+        # Set turn volume based on balancer results
+        for (i, j, k), col in result.matrix_cols_turns.items():
+            self.net.turn(i, j, k).assigned_volume = result.balancer_est[col]
+        
+        # Set link volume based on turn volumes
+        self.net.assign_link_volume_from_turns()
         self.net.calc_link_imbalance()
 
     def get_nodes(self) -> list['NetNode']:

--- a/stesso/network/net.py
+++ b/stesso/network/net.py
@@ -125,7 +125,7 @@ class Network():
             else:
                 yield turn
 
-    def assign_link_flows(self):
+    def init_link_flow_lists(self):
         """Assign inbound and outbound turns for each link."""
         for (i, j, k), _ in self.turns(True):
             # if i == k:
@@ -154,6 +154,24 @@ class Network():
                 vol_out += self.turn(d, e, f).assigned_volume
                         
             link.imbalance = vol_out - vol_in
+
+    def assign_link_volume_from_turns(self) -> None:
+        """Calculate the link volume based on outbound turning volumes.
+        
+        If the link only has inbound turns, then they will be used to compute
+        the link volume.
+        """
+        for link in self.links():
+            link_volume = 0
+            
+            if len(link.turns_out) == 0:
+                for (a, b, c) in link.turns_in:
+                    link_volume += self.turn(a, b, c).assigned_volume
+            else:
+                for (d, e, f) in link.turns_out:
+                    link_volume += self.turn(d, e, f).assigned_volume
+            
+            link.assigned_volume = link_volume
 
     def init_turns(self) -> None:
         """Initialize all turns within the network.

--- a/stesso/network/net_read.py
+++ b/stesso/network/net_read.py
@@ -63,7 +63,7 @@ def create_network(node_file: str, link_file: str) -> Network:
     link_handler[link_file_ext](new_network, link_file)
 
     new_network.init_turns()
-    new_network.assign_link_flows()
+    new_network.init_link_flow_lists()
     new_network.init_routes()
     new_network.set_coord_scale()
     

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -40,7 +40,7 @@ class MainTest(unittest.TestCase):
         self.window.dialog_open.ui.leTurns.setText(os.path.join(net_folder, "turn targets.csv"))
         QTest.mouseClick(self.window.dialog_open.ui.buttonBox.button(QDialogButtonBox.Ok), Qt.LeftButton)
         
-        self.model.balance_volumes()
+        QTest.mouseClick(self.window.ui.pbBalance, Qt.LeftButton)
         
         QTest.mouseClick(self.window.ui.pbShowExportDialog, Qt.LeftButton)
         self.window.dialog_export.ui.leExportFolder.setText(export_folder)


### PR DESCRIPTION
Changes in this pull request include:

- The responsibility of assigning link/turn volumes is taken away from the balancing function and moved to the model. 
- Link volumes estimated from the balancing function are derived from turning volumes. This eliminates discrepancy where the balancer can estimate link volumes that do not match either the inbound or outbound turning volumes.
- Minor edits to naming and tests.
 
Pull request is preparing for addressing #12.