### PR TITLE
Optimize labels for rendering speed

### DIFF
--- a/stesso/gui/approach_tmarrow.py
+++ b/stesso/gui/approach_tmarrow.py
@@ -4,8 +4,7 @@ from PySide2.QtWidgets import QGraphicsItem
 from PySide2.QtGui import QPen
 from PySide2.QtCore import Qt, QRectF, QLineF
 
-
-SCALE_VALUE = 22
+from gui.settings import GUIConfig
 
 
 class TMArrow(QGraphicsItem):
@@ -16,19 +15,22 @@ class TMArrow(QGraphicsItem):
         self.angle_rel = angle_rel
     
     def boundingRect(self):
-        return QRectF(0, 0, SCALE_VALUE, SCALE_VALUE)
+        return QRectF(0, 0, GUIConfig.FONT_HEIGHT, GUIConfig.FONT_HEIGHT)
     
     def paint(self, painter, option, widget) -> None:
+        lod = option.levelOfDetailFromTransform(painter.worldTransform())
+        painter.scale(1 / lod, 1 / lod)
+
         painter.drawRect(self.boundingRect())
         
-        line_in = QLineF(0, 0, SCALE_VALUE * 0.4, 0)
+        line_in = QLineF(0, 0, GUIConfig.FONT_HEIGHT * 0.4, 0)
         # Line_in always has zero angle because it is parallel to the approach,
         # so we don't need to call setAngle(). We only need to call translate()
-        line_in.translate(SCALE_VALUE / 2, SCALE_VALUE / 2)
+        line_in.translate(GUIConfig.FONT_HEIGHT / 2, GUIConfig.FONT_HEIGHT / 2)
         
-        line_out = QLineF(0, 0, SCALE_VALUE * 0.4, 0)
+        line_out = QLineF(0, 0, GUIConfig.FONT_HEIGHT * 0.4, 0)
         line_out.setAngle(self.angle_rel)
-        line_out.translate(SCALE_VALUE / 2, SCALE_VALUE / 2)
+        line_out.translate(GUIConfig.FONT_HEIGHT / 2, GUIConfig.FONT_HEIGHT / 2)
         
         painter.setPen(QPen(Qt.green, 3))
         painter.drawLine(line_in)

--- a/stesso/gui/approach_tmhint.py
+++ b/stesso/gui/approach_tmhint.py
@@ -4,7 +4,7 @@ from PySide2.QtGui import QPen, QPolygonF
 from PySide2.QtCore import Qt, QLineF
 
 
-SCALE_VALUE = 22
+
 
 
 class TMHint(QGraphicsItem):

--- a/stesso/gui/mainwindow.py
+++ b/stesso/gui/mainwindow.py
@@ -13,6 +13,8 @@ from gui.dialog_export import DialogExport
 from gui.dialog_vol_input import DialogVolInput
 from gui import label_props
 
+from gui import settings
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -28,6 +30,8 @@ class MainWindow(QMainWindow):
         self.ui.setupUi(self)
 
         self.ui.statusbar.showMessage("Hello from Status Bar!", 10000)
+
+        settings.init()
 
         # Connect MainWindow view/controller to model
         self.model: 'Model' = model
@@ -56,13 +60,14 @@ class MainWindow(QMainWindow):
         self.schematic_scene: schematic_scene.SchematicScene = schematic_scene.SchematicScene()
         self.ui.gvSchematic.setScene(self.schematic_scene)
         self.ui.gvSchematic.setRenderHints(QPainter.Antialiasing)
+        self.ui.gvSchematic.setRenderHint(QPainter.SmoothPixmapTransform)
         
         # Experimenting with font properties
-        font = QFont("consolas", 14)
-        fm = QFontMetrics(font)
-        print(f"fm.height = {fm.height()}")
-        print(f"fm.averageCharWidth = {fm.averageCharWidth()}")
-        print(f"fm.horizontalAdvance(1234) = {fm.horizontalAdvance('1234')}")
+        # font = QFont("consolas", 8)
+        # fm = QFontMetrics(font)
+        # print(f"fm.height = {fm.height()} fm.capHeight = {fm.capHeight()}")
+        # print(f"fm.averageCharWidth = {fm.averageCharWidth()}")
+        # print(f"fm.horizontalAdvance(1234) = {fm.horizontalAdvance('1234')}")
 
     def clear_label_selection(self):
         self.schematic_scene.clear_label_selection()

--- a/stesso/gui/node_label.py
+++ b/stesso/gui/node_label.py
@@ -1,0 +1,48 @@
+from PySide2.QtWidgets import QGraphicsItem
+from PySide2.QtGui import QFont, QPainter, QPixmap, QBrush
+from PySide2.QtCore import Qt, QRectF, QPoint
+
+
+SCALE_VALUE = 22
+AVG_CHAR_WIDTH = 10
+CHAR_CAP_HEIGHT = 12
+
+
+class NodeLabel(QGraphicsItem):
+    def __init__(self, parent, text: str) -> None:
+        super().__init__(parent)
+
+        self.text = text
+        self.font = QFont("consolas", 14)
+
+        self.antialias_scale = 2
+        self.text_pixmap = self._setup_text_pixmap()
+
+    def _setup_text_pixmap(self):
+        
+        width_px = (len(self.text) * AVG_CHAR_WIDTH) * self.antialias_scale
+        height_px = CHAR_CAP_HEIGHT * self.antialias_scale
+
+        canvas = QPixmap(width_px, height_px)
+        canvas.fill(Qt.transparent)
+        painter = QPainter(canvas)
+
+        font = QFont("consolas", 14 * self.antialias_scale)
+        painter.setFont(font)
+        painter.setPen(Qt.blue)
+
+        painter.scale(1.0, -1.0)
+        painter.drawText(0, 0, self.text)
+
+        return canvas
+
+    def boundingRect(self):
+        return QRectF(0, 0, len(self.text) * AVG_CHAR_WIDTH, CHAR_CAP_HEIGHT)
+
+    def paint(self, painter, option, widget) -> None:
+        lod = option.levelOfDetailFromTransform(painter.worldTransform())
+        scale_mult = (1 / self.antialias_scale) / lod
+        painter.scale(scale_mult, scale_mult)
+        
+        painter.drawPixmap(QPoint(0, 0), self.text_pixmap)
+        

--- a/stesso/gui/schematic_items.py
+++ b/stesso/gui/schematic_items.py
@@ -6,6 +6,8 @@ from PySide2.QtGui import QPainter, QPen, QColor, QPainterPath, QFont, QPolygonF
 from PySide2.QtWidgets import QStyleOptionGraphicsItem, QWidget
 from PySide2.QtCore import Qt
 
+from .node_label import NodeLabel
+
 
 class LinkItem(QGraphicsItem):
     """GraphicsItem for network links.
@@ -55,8 +57,11 @@ class NodeItem(QGraphicsItem):
         self.x = x
         self.y = y
         self.name = name
-        self.diameter = 5
+        self.diameter = 8.0
         self.pen_width = 1
+
+        self.node_label = NodeLabel(self, self.name)
+        self.node_label.setPos(self.x, self.y)
     
     def boundingRect(self) -> QRectF:
         return QRectF(self.x - self.diameter / 2 - self.pen_width, 
@@ -66,39 +71,20 @@ class NodeItem(QGraphicsItem):
 
     def paint(self, painter: QPainter, option: QStyleOptionGraphicsItem, widget: Optional[QWidget]) -> None:
 
-        # Draw a circle for the node
-        pen = QPen(Qt.gray)
-        pen.setWidth(2)
+        pen = QPen(Qt.blue)
+        pen.setWidth(self.pen_width)
         pen.setCosmetic(True)
-
-        # Combine ideas from these code samples to draw items at a fixed size:
-        # https://stackoverflow.com/questions/1222914/qgraphicsview-and-qgraphicsitem-don%C2%B4t-scale-item-when-scaling-the-view-rect
-        # https://www.qtcentre.org/threads/28691-Scale-independent-QGraphicsItem
-
-        object_rect = self.boundingRect()
-        mapped_rect = painter.transform().mapRect(object_rect)
-        
-        width_ratio = object_rect.width() / mapped_rect.width()
-
-        scale_factor = max(1, width_ratio)
 
         painter.setPen(pen)
         painter.setBrush(Qt.gray)
 
-        scaled_diameter = self.diameter * scale_factor
+        lod = option.levelOfDetailFromTransform(painter.worldTransform())
+        painter.scale(1 / lod, 1 / lod)
 
-        painter.drawEllipse((self.x - scaled_diameter / 2), 
-                            (self.y - scaled_diameter / 2), 
-                            scaled_diameter,
-                            scaled_diameter)
+        painter.drawEllipse((self.x * lod) - self.diameter / 2, 
+                            (self.y * lod) - self.diameter / 2, 
+                            self.diameter,
+                            self.diameter)
 
-        # Draw text for the node name
-        label_path = QPainterPath()
-        label_font = QFont("Calibri", 10 * scale_factor)
-        label_path.addText(self.x, -self.y - self.diameter / 2, label_font, self.name)
-        painter.scale(1.0, -1.0)
-        
-        painter.setBrush(Qt.blue)
-        painter.setPen(Qt.NoPen)
-        painter.drawPath(label_path)
+
         

--- a/stesso/gui/schematic_scene.py
+++ b/stesso/gui/schematic_scene.py
@@ -118,7 +118,8 @@ class SchematicScene(QGraphicsScene):
         for _, link in self.links.items():
             new_link_label = LinkLabel(link, label_props, get_data_fn)
             self.addItem(new_link_label)
-            new_link_label.setPos(new_link_label.get_offset())
+            #new_link_label.setPos(new_link_label.get_offset())
+            # new_link_label.init_pos()
             self.link_labels.append(new_link_label)
 
     def _create_approach_labels(self, 
@@ -130,7 +131,6 @@ class SchematicScene(QGraphicsScene):
                 lbl = self._create_approach_label(node.key, approach, label_props, get_data_fn)
                 self.approach_labels.append(lbl)
                 self.addItem(lbl)
-                lbl.setPos(lbl.get_offset())
 
                 # Add Turn Hints
                 for (turn_key, t) in lbl.turns.items():
@@ -139,7 +139,7 @@ class SchematicScene(QGraphicsScene):
                     self.addItem(tm_hint)
 
                 # For Debug
-                self.addEllipse(lbl.pos().x(), lbl.pos().y(), 5, 5)
+                # self.addEllipse(lbl.pos().x(), lbl.pos().y(), 5, 5)
 
     def _create_approach_label(self, 
                                node_key: int, 

--- a/stesso/gui/settings.py
+++ b/stesso/gui/settings.py
@@ -1,0 +1,30 @@
+from PySide2.QtGui import QFont, QFontMetrics
+
+class GUIConfig:
+    FONT_NAME = "consolas"
+    FONT_SIZE = 8
+    
+    # Derived settings set by calling init() function
+    QFONT = None
+    QFONTMETRICS = None
+    FONT_HEIGHT = 0
+    CHAR_WIDTH = 0
+    CAP_HEIGHT = 0
+
+# _config = {
+#     "FONT_NAME": "consolas",
+#     "FONT_SIZE": 8
+# }
+
+# TODO: Need a more elegant way of handling settings.
+# As another hack, try adding module-level names:
+# https://stackoverflow.com/questions/1429814/how-to-programmatically-set-a-global-module-variable
+
+# Derived settings set by calling init() function
+def init():
+    GUIConfig.QFONT = QFont(GUIConfig.FONT_NAME, GUIConfig.FONT_SIZE)
+    GUIConfig.QFONTMETRICS = QFontMetrics(GUIConfig.QFONT)
+
+    GUIConfig.FONT_HEIGHT = GUIConfig.QFONTMETRICS.height()
+    GUIConfig.CHAR_WIDTH = GUIConfig.QFONTMETRICS.averageCharWidth()
+    GUIConfig.CAP_HEIGHT = GUIConfig.QFONTMETRICS.capHeight()


### PR DESCRIPTION
Closes #13. Changes include:

- Render text using pixmaps. `drawPixmap` is much faster than `drawText`, especially for rotated text.
- Move node numbers to their own class and file (node_label.py).
- Draw text at a constant size, regardless of zoom.
- Move font properties to a settings.py file. This is a bit of a hack, and could use some research on how to better share settings across files.