### PR TITLE
Fixing redraw artifacts and text offset

### DIFF
--- a/stesso/gui/approach_label.py
+++ b/stesso/gui/approach_label.py
@@ -146,7 +146,7 @@ class ApproachLabel(QGraphicsItem):
                 new_text = txt.update_text(data)
                 self.col_max_char[col] = max(len(new_text), self.col_max_char[col])
 
-        self._update_text_pos()
+        self._update_text_pos(self.lod)
 
         self.width = 0
         for col in range(self.n_cols):
@@ -184,6 +184,7 @@ class ApproachLabel(QGraphicsItem):
     def update_self_pos(self):
         self.offset.setLength(self.offset_length / self.lod)
         self.setPos(self.offset.p2())
+        self._update_text_pos(self.lod)
     
     def update_offset(self):
         print(f"update_offset self.pos: {self.pos()}")
@@ -214,13 +215,20 @@ class ApproachLabel(QGraphicsItem):
                       self.width / self.lod,
                       (self.height + 20) / self.lod)
 
+
+    def set_lod(self, lod):
+        self.prepareGeometryChange()
+        self.lod = lod
+
     def paint(self, painter, option, widget) -> None:
-        if not self.mouse_down:
+        self.prepareGeometryChange()
+        self.lod = option.levelOfDetailFromTransform(painter.worldTransform())
+
+        if self.mouse_down:
+            self._update_text_pos(self.lod)
+        else:
             self.update_self_pos()
         
-        self.lod = option.levelOfDetailFromTransform(painter.worldTransform())
-        self._update_text_pos(self.lod)
-
         #print(f"paint: {self.lod}")
         # if self.flip:
         #     # # Draw Bounding Rect for debugging

--- a/stesso/gui/approach_tmarrow.py
+++ b/stesso/gui/approach_tmarrow.py
@@ -19,6 +19,7 @@ class TMArrow(QGraphicsItem):
         return QRectF(0, 0, GUIConfig.FONT_HEIGHT / self.lod, GUIConfig.FONT_HEIGHT / self.lod)
     
     def paint(self, painter, option, widget) -> None:
+        self.prepareGeometryChange()
         self.lod = option.levelOfDetailFromTransform(painter.worldTransform())
         painter.scale(1 / self.lod, 1 / self.lod)
 

--- a/stesso/gui/node_label.py
+++ b/stesso/gui/node_label.py
@@ -45,6 +45,7 @@ class NodeLabel(QGraphicsItem):
                       CHAR_CAP_HEIGHT / self.lod)
 
     def paint(self, painter, option, widget) -> None:
+        self.prepareGeometryChange()
         self.lod = option.levelOfDetailFromTransform(painter.worldTransform())
                 
         scale_mult = (1 / self.antialias_scale) / self.lod

--- a/stesso/gui/schematic_scene.py
+++ b/stesso/gui/schematic_scene.py
@@ -166,12 +166,16 @@ class SchematicScene(QGraphicsScene):
         ap_label.setFlag(QGraphicsItem.ItemIsMovable)
         return ap_label
     
-    def hide_approach_labels(self) -> None:
+    def hide_approach_labels(self, lod) -> None:
         for lbl in self.approach_labels:
+            lbl.set_lod(lod)
+            lbl.update_self_pos()
             lbl.setVisible(False)
 
-    def show_approach_labels(self) -> None:
+    def show_approach_labels(self, lod) -> None:
         for lbl in self.approach_labels:
+            lbl.set_lod(lod)
+            lbl.update_self_pos()
             lbl.setVisible(True)
 
     def update_approach_labels(self) -> None:

--- a/stesso/gui/schematic_view.py
+++ b/stesso/gui/schematic_view.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QGraphicsView
+from PySide2.QtWidgets import QGraphicsView, QStyleOptionGraphicsItem
 import PySide2.QtCore
 
 from typing import TYPE_CHECKING
@@ -23,11 +23,12 @@ class SchematicView(QGraphicsView):
     def set_prev_scale(self):
         self.prev_scale = self.transform().m11()
         print(f"in set_prev_scale: {self.prev_scale}")
+        lod = QStyleOptionGraphicsItem.levelOfDetailFromTransform(self.transform())
         if self.prev_scale < self.vis_threshold_for_approach_label:
-            self.scene().hide_approach_labels()
+            self.scene().hide_approach_labels(lod)
             print("change vis")
         elif self.prev_scale >= self.vis_threshold_for_approach_label:
-            self.scene().show_approach_labels()
+            self.scene().show_approach_labels(lod)
             print("change vis")       
 
     def wheelEvent(self, event: 'PySide2.QtGui.QWheelEvent') -> None:
@@ -35,6 +36,17 @@ class SchematicView(QGraphicsView):
         # Zoom to point under mouse cursor.
         # https://stackoverflow.com/questions/58965209/zoom-on-mouse-position-qgraphicsview
         # https://stackoverflow.com/questions/19113532/qgraphicsview-zooming-in-and-out-under-mouse-position-using-mouse-wheel
+
+        # self.fitInView(PySide2.QtCore.QRectF(27406.520785, 8102.370929, 89.298811, 42.243853))
+        lod = QStyleOptionGraphicsItem.levelOfDetailFromTransform(self.transform())
+        # print(f"wheelEvent: (m11, m22) = ({self.transform().m11()} {self.transform().m22()}) {lod}")
+
+        # self.scene().show_approach_labels(QStyleOptionGraphicsItem.levelOfDetailFromTransform(self.transform()))
+
+        # self.scene().update()
+        # self.update()        
+        
+        # return super().wheelEvent(event)
 
         previous_anchor = self.transformationAnchor()
         self.setTransformationAnchor(QGraphicsView.AnchorUnderMouse)
@@ -46,18 +58,24 @@ class SchematicView(QGraphicsView):
         self.scale(zoom_factor, zoom_factor)
         self.setTransformationAnchor(previous_anchor)
 
-        print(f"view transform m11: {self.transform().m11()} m22: {self.transform().m22()}")
+        # print(f"view transform m11: {self.transform().m11()} m22: {self.transform().m22()}")
         new_scale = self.transform().m11()
         # scale_delta = new_scale - self.vis_threshold_for_approach_label
 
         if new_scale < self.vis_threshold_for_approach_label and \
            self.prev_scale >= self.vis_threshold_for_approach_label:
-            self.scene().hide_approach_labels()
-            print("change vis")
+            self.scene().hide_approach_labels(lod)
+            print("change vis - hide labels")
         elif new_scale >= self.vis_threshold_for_approach_label and \
              self.prev_scale < self.vis_threshold_for_approach_label:
-            self.scene().show_approach_labels()
-            print("change vis")
+            
+            # self.scene().invalidate(self.scene().sceneRect())
+            # self.scene().update()
+            # self.update()
+            # self.viewport().repaint()
+
+            self.scene().show_approach_labels(lod)
+            print("change vis - show labels")
 
         self.prev_scale = new_scale
 

--- a/stesso/gui/settings.py
+++ b/stesso/gui/settings.py
@@ -10,6 +10,7 @@ class GUIConfig:
     """
     FONT_NAME = "consolas"
     FONT_SIZE = 9
+    FONT_ANTIALIAS = 2.0
     
     # Derived config variables
     QFONT = None
@@ -17,6 +18,8 @@ class GUIConfig:
     FONT_HEIGHT = 0
     CHAR_WIDTH = 0
     CAP_HEIGHT = 0
+    AA_CHAR_WIDTH = 0
+    AA_CAP_HEIGHT = 0
 
 # TODO: Need a more elegant way of handling settings.
 # As another hack, try adding module-level names:
@@ -32,3 +35,9 @@ def init():
     GUIConfig.FONT_HEIGHT = GUIConfig.QFONTMETRICS.height()
     GUIConfig.CHAR_WIDTH = GUIConfig.QFONTMETRICS.averageCharWidth()
     GUIConfig.CAP_HEIGHT = GUIConfig.QFONTMETRICS.capHeight()
+
+    # Font Properties for scaled (Anti-Aliased) font
+    aa_font = QFont(GUIConfig.FONT_NAME, GUIConfig.FONT_SIZE * GUIConfig.FONT_ANTIALIAS)
+    aa_fm = QFontMetrics(aa_font)
+    GUIConfig.AA_CHAR_WIDTH = aa_fm.averageCharWidth()
+    GUIConfig.AA_CAP_HEIGHT = aa_fm.capHeight()


### PR DESCRIPTION
- Fixes redraw artifacts by calling `self.prepareGeometryChange()` before making changes to `boundingRect()`
- Updates `approach_label` and `label_text` item positions during scroll events so that way the graphics view index stays current with where items are drawn on the canvas. This allows items near the edge of the view to be displayed instead of omitted.
- `label_text` scaling (anti-aliasing) now considers the true character width of the scaled font, which is not guaranteed to equal to the base (non-aliased) character width. 